### PR TITLE
Updated broken link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 


### PR DESCRIPTION
I noticed that the Auth0 author link was broken due to not having https:// in the URL.